### PR TITLE
Use hamcrest-core instead of hamcrest-all.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 	<dependencies>
 		<dependency>
 			<groupId>org.hamcrest</groupId>
-			<artifactId>hamcrest-all</artifactId>
+			<artifactId>hamcrest-core</artifactId>
 			<version>1.3</version>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
hamcrest-all conflicts with JUnit because hamcrest-all contains classes
from hamcrest-core that is a dependency of JUnit, too.
