### PR TITLE
Rename isPresentAnd to hasValue.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ It provides matchers such as:
 
  - `isEmpty()` - Matches if optional is empty
 
- - `isPresentAnd(Matcher<T> m)` - Matches if optional is present and matches provided matcher.
+ - `hasValue(Matcher<T> m)` - Matches if optional contains a value that satisfies the specified matcher.
 
 ##Usage
 ###`isPresent()`
@@ -27,11 +27,11 @@ Optional<String> optionalRef = someMethodReturningOptional();
 assertThat(optionalRef, isEmpty());
 ```
 
-###`isPresentAnd(Matcher<? super T> m)`
+###`hasValue(Matcher<? super T> m)`
 
 ```java
 Optional<String> optionalRef = someMethodReturningOptional();
-assertThat(optionalRef, isPresentAnd(startsWith("a"));
+assertThat(optionalRef, hasValue(startsWith("a"));
 ```
 
 ## Development Guide

--- a/src/main/java/com/github/npathai/hamcrestext/matcher/OptionalMatcher.java
+++ b/src/main/java/com/github/npathai/hamcrestext/matcher/OptionalMatcher.java
@@ -63,18 +63,27 @@ public class OptionalMatcher {
 	}
 
 	/**
-	 * @return a matcher which matches if Optional is present and also matches 
-	 * provided {@code matcher}
+	 * Creates a matcher that matches when the examined {@code Optional}
+	 * contains a value that satisfies the specified matcher.
+	 * <pre>
+	 *     Optional&lt;String&gt; optionalObject = Optional.of("dummy value");
+	 *     assertThat(optionalObject, hasValue(startsWith("dummy")));
+	 * </pre>
+	 *
+	 * @param matcher a matcher for the value of the examined {@code Optional}.
+	 * @param <T> the class of the value.
+	 * @return  a matcher that matches when the examined {@code Optional}
+	 * contains a value that satisfies the specified matcher.
 	 */
-	public static <T> Matcher<Optional<T>> isPresentAnd(Matcher<? super T> matcher) {
-		return new PresentAndMatcher<>(matcher);
+	public static <T> Matcher<Optional<T>> hasValue(Matcher<? super T> matcher) {
+		return new HasValue<>(matcher);
 	}
 
-	private static class PresentAndMatcher<T> extends TypeSafeMatcher<Optional<T>> {
+	private static class HasValue<T> extends TypeSafeMatcher<Optional<T>> {
 		private PresenceMatcher presenceMatcher = new PresenceMatcher();
 		private Matcher<? super T> matcher;
 		
-		public PresentAndMatcher(Matcher<? super T> matcher) {
+		public HasValue(Matcher<? super T> matcher) {
 			this.matcher = matcher;
 		}
 		

--- a/src/test/java/com/github/npathai/hamcrestext/matcher/OptionalMatcherTest.java
+++ b/src/test/java/com/github/npathai/hamcrestext/matcher/OptionalMatcherTest.java
@@ -56,27 +56,27 @@ public class OptionalMatcherTest {
 	}
 	
 	@Test
-	public void testIsPresentAnd_ShouldReturnAMatcher_WhichFailsIfOptionalIsEmpty() {
+	public void testHasValue_ShouldReturnAMatcher_WhichFailsIfOptionalIsEmpty() {
 		exception.expect(AssertionError.class);
 		exception.expectMessage("was <Empty>");
 		
 		Optional<String> hello = Optional.empty();
-		assertThat(hello, isPresentAnd(startsWith("a")));
+		assertThat(hello, hasValue(startsWith("a")));
 	}
 	
 	@Test
-	public void testIsPresentAnd_ShouldReturnAMatcher_WhichSucceedsIfOptionalIsPresent_AndPassedMatcher_Succeeds() {
+	public void testHasValue_ShouldReturnAMatcher_WhichSucceedsIfOptionalIsPresent_AndPassedMatcher_Succeeds() {
 		Optional<String> hello = Optional.of("hello");
-		assertThat(hello, isPresentAnd(allOf(startsWith("h"), endsWith("o"))));
+		assertThat(hello, hasValue(allOf(startsWith("h"), endsWith("o"))));
 	}
 	
 	@Test
-	public void testIsPresentAnd_ShouldReturnAMatcher_WhichFailsIfOptionalIsPresent_ButPassedMatcher_Fails() {
+	public void testHasValue_ShouldReturnAMatcher_WhichFailsIfOptionalIsPresent_ButPassedMatcher_Fails() {
 		exception.expect(AssertionError.class);
 		exception.expectMessage("was <Present> and");
 		exception.expectMessage("was \"hello\"");
 		
 		Optional<String> hello = Optional.of("hello");
-		assertThat(hello, isPresentAnd(startsWith("a")));
+		assertThat(hello, hasValue(startsWith("a")));
 	}
 }


### PR DESCRIPTION
`hasValue` is more concise. It is the same wording that is used by [hamcrest-extras](https://github.com/gkonst/hamcrest-extras) (Hamcrest matchers for Guava's Optional) and [AssertJ](http://joel-costigliola.github.io/assertj/assertj-core-news.html#assertj-core-3.2.0-optional-hasValue).
