### PR TITLE
Rename library to hamcrest-optional.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# hamcrest-jdk8-extras
+# Hamcrest Optional
 [![Travis CI build](https://travis-ci.org/npathai/hamcrest-jdk8-extras.svg?branch=master)](https://travis-ci.org/npathai/hamcrest-jdk8-extras)   [![Coverage Status](https://coveralls.io/repos/npathai/hamcrest-jdk8-extras/badge.svg?branch=master&service=github)](https://coveralls.io/github/npathai/hamcrest-jdk8-extras?branch=master)
 
 An extension to [Java Hamcrest](https://github.com/hamcrest/JavaHamcrest) which provides matchers for *JDK 8* Optional

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>com.github.npathai</groupId>
-	<artifactId>hamcrestext</artifactId>
+	<artifactId>hamcrest-optional</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
 	<packaging>jar</packaging>
 


### PR DESCRIPTION
Reduce the scope of the library to the one thing and clearly communicate that scope. When I was searching for such a library I searched for the keywords "Hamcrest" and "Optional". I think others will do, too.
