### PR TITLE
Add convenience method hasValue(Object).

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,13 @@ Optional<String> optionalRef = someMethodReturningOptional();
 assertThat(optionalRef, isEmpty());
 ```
 
+###`hasValue(Object operand)`
+
+```java
+Optional<String> optionalRef = someMethodReturningOptional();
+assertThat(optionalRef, hasValue("expected value");
+```
+
 ###`hasValue(Matcher<? super T> m)`
 
 ```java

--- a/src/main/java/com/github/npathai/hamcrestext/matcher/OptionalMatcher.java
+++ b/src/main/java/com/github/npathai/hamcrestext/matcher/OptionalMatcher.java
@@ -6,6 +6,8 @@ import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
 
+import static org.hamcrest.core.IsEqual.equalTo;
+
 /**
  * Provides matchers for JDK 8 {@link Optional}
  * 
@@ -76,6 +78,25 @@ public class OptionalMatcher {
 		protected void describeMismatchSafely(Optional<?> item, Description mismatchDescription) {
 			mismatchDescription.appendText("was <Present> with value " + item.get());
 		}
+	}
+
+	/**
+	 * Creates a matcher that matches when the examined {@code Optional}
+	 * contains a value that is logically equal to the {@code operand}, as
+	 * determined by calling the {@code equals} method on the value.
+	 * <pre>
+	 *     Optional&lt;String&gt; optionalInt = Optional.of("dummy value");
+	 *     assertThat(optionalInt, hasValue("dummy value"));
+	 * </pre>
+	 *
+	 * @param operand the object that any examined {@code Optional} value
+	 * should equal
+	 * @param <T> the class of the value.
+	 * @return  a matcher that matches when the examined {@code Optional}
+	 * contains a value that is logically equal to the {@code operand}.
+	 */
+	public static <T> Matcher<Optional<T>> hasValue(T operand) {
+		return new HasValue<>(equalTo(operand));
 	}
 
 	/**

--- a/src/test/java/com/github/npathai/hamcrestext/matcher/OptionalMatcherTest.java
+++ b/src/test/java/com/github/npathai/hamcrestext/matcher/OptionalMatcherTest.java
@@ -54,9 +54,34 @@ public class OptionalMatcherTest {
 		
 		assertThat("An optional with some value should not be empty", myOptionalRef, isEmpty());
 	}
+
+	@Test
+	public void testHasValue_Object_ShouldReturnAMatcher_WhichFailsIfOptionalIsEmpty() {
+		exception.expect(AssertionError.class);
+		exception.expectMessage("was <Empty>");
+
+		Optional<String> optional = Optional.empty();
+		assertThat(optional, hasValue("dummy value"));
+	}
+
+	@Test
+	public void testHasValue_Object_ShouldReturnAMatcher_WhichSucceedsIfOptionalContainsValueEqualToOperand() {
+		Optional<String> optional = Optional.of("dummy value");
+		assertThat(optional, hasValue("dummy value"));
+	}
+
+	@Test
+	public void testHasValue_Object_ShouldReturnAMatcher_WhichFailsIfOptionalContainsValueNotEqualToOperand() {
+		exception.expect(AssertionError.class);
+		exception.expectMessage("was <Present> and");
+		exception.expectMessage("was \"dummy value\"");
+
+		Optional<String> optional = Optional.of("dummy value");
+		assertThat(optional, hasValue("another value"));
+	}
 	
 	@Test
-	public void testHasValue_ShouldReturnAMatcher_WhichFailsIfOptionalIsEmpty() {
+	public void testHasValue_Matcher_ShouldReturnAMatcher_WhichFailsIfOptionalIsEmpty() {
 		exception.expect(AssertionError.class);
 		exception.expectMessage("was <Empty>");
 		
@@ -65,13 +90,13 @@ public class OptionalMatcherTest {
 	}
 	
 	@Test
-	public void testHasValue_ShouldReturnAMatcher_WhichSucceedsIfOptionalIsPresent_AndPassedMatcher_Succeeds() {
+	public void testHasValue_Matcher_ShouldReturnAMatcher_WhichSucceedsIfOptionalIsPresent_AndPassedMatcher_Succeeds() {
 		Optional<String> hello = Optional.of("hello");
 		assertThat(hello, hasValue(allOf(startsWith("h"), endsWith("o"))));
 	}
 	
 	@Test
-	public void testHasValue_ShouldReturnAMatcher_WhichFailsIfOptionalIsPresent_ButPassedMatcher_Fails() {
+	public void testHasValue_Matcher_ShouldReturnAMatcher_WhichFailsIfOptionalIsPresent_ButPassedMatcher_Fails() {
 		exception.expect(AssertionError.class);
 		exception.expectMessage("was <Present> and");
 		exception.expectMessage("was \"hello\"");


### PR DESCRIPTION
The new method is a shortcut for `hasValue(equalTo(Object))` for the
most common use case. Very often I check that an optional contains a
value that is equal to a known value.
