### PR TITLE
Rename OptionalMatcher to OptionalMatchers.

### DIFF
--- a/src/main/java/com/github/npathai/hamcrestext/matcher/OptionalMatchers.java
+++ b/src/main/java/com/github/npathai/hamcrestext/matcher/OptionalMatchers.java
@@ -14,7 +14,7 @@ import static org.hamcrest.core.IsEqual.equalTo;
  * @author npathai
  *
  */
-public class OptionalMatcher {
+public class OptionalMatchers {
 
 	/**
 	 * Creates a matcher that matches when the examined {@code Optional}
@@ -149,6 +149,6 @@ public class OptionalMatcher {
 	}
 
 	//This is an utility class that must not be instantiated.
-	private OptionalMatcher() {
+	private OptionalMatchers() {
 	}
 }

--- a/src/test/java/com/github/npathai/hamcrestext/matcher/OptionalMatchersTest.java
+++ b/src/test/java/com/github/npathai/hamcrestext/matcher/OptionalMatchersTest.java
@@ -1,7 +1,6 @@
 package com.github.npathai.hamcrestext.matcher;
 
-import static com.github.npathai.hamcrestext.matcher.OptionalMatcher.isEmpty;
-import static com.github.npathai.hamcrestext.matcher.OptionalMatcher.*;
+import static com.github.npathai.hamcrestext.matcher.OptionalMatchers.*;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.endsWith;
 import static org.hamcrest.CoreMatchers.startsWith;
@@ -13,7 +12,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-public class OptionalMatcherTest {
+public class OptionalMatchersTest {
 
 	private static final Object ANY_VALUE = "value";
 


### PR DESCRIPTION
Hamcrest itself uses classes with plural names for collections of matchers. E.g. org.hamcrest.Matchers and org.hamcrest.CoreMatchers.
