### PR TITLE
Improve descriptions of matchers.

### DIFF
--- a/src/main/java/com/github/npathai/hamcrestext/matcher/OptionalMatchers.java
+++ b/src/main/java/com/github/npathai/hamcrestext/matcher/OptionalMatchers.java
@@ -45,7 +45,7 @@ public class OptionalMatchers {
 	private static class PresenceMatcher extends TypeSafeMatcher<Optional<?>> {
 		
 		public void describeTo(Description description) {
-			description.appendText("<Present>");
+			description.appendText("is <Present>");
 		}
 
 		@Override
@@ -77,7 +77,7 @@ public class OptionalMatchers {
 	private static class EmptyMatcher extends TypeSafeMatcher<Optional<?>> {
 
 		public void describeTo(Description description) {
-			description.appendText("<Empty>");
+			description.appendText("is <Empty>");
 		}
 
 		@Override
@@ -87,7 +87,8 @@ public class OptionalMatchers {
 		
 		@Override
 		protected void describeMismatchSafely(Optional<?> item, Description mismatchDescription) {
-			mismatchDescription.appendText("was <Present> with value " + item.get());
+			mismatchDescription.appendText("had value ");
+			mismatchDescription.appendValue(item.get());
 		}
 	}
 
@@ -128,7 +129,6 @@ public class OptionalMatchers {
 	}
 
 	private static class HasValue<T> extends TypeSafeMatcher<Optional<T>> {
-		private PresenceMatcher presenceMatcher = new PresenceMatcher();
 		private Matcher<? super T> matcher;
 		
 		public HasValue(Matcher<? super T> matcher) {
@@ -137,24 +137,22 @@ public class OptionalMatchers {
 		
 		@Override
 		public void describeTo(Description description) {
-			presenceMatcher.describeTo(description);
-			description.appendText(" and ");
+			description.appendText("has value that is ");
 			matcher.describeTo(description);
 		}
 
 		@Override
 		protected boolean matchesSafely(Optional<T> item) {
-			return presenceMatcher.matchesSafely(item) 
-					&& matcher.matches(item.get());
+			return item.isPresent() && matcher.matches(item.get());
 		}
 		
 		@Override
 		protected void describeMismatchSafely(Optional<T> item, Description mismatchDescription) {
-			if (!presenceMatcher.matchesSafely(item)) {
-				mismatchDescription.appendText("was <Empty>");
-			} else {
-				mismatchDescription.appendText("was <Present> and ");
+			if (item.isPresent()) {
+				mismatchDescription.appendText("value ");
 				matcher.describeMismatch(item.get(), mismatchDescription);
+			} else {
+				mismatchDescription.appendText("was <Empty>");
 			}
 		}
 	}

--- a/src/test/java/com/github/npathai/hamcrestext/matcher/OptionalMatchersTest.java
+++ b/src/test/java/com/github/npathai/hamcrestext/matcher/OptionalMatchersTest.java
@@ -1,6 +1,7 @@
 package com.github.npathai.hamcrestext.matcher;
 
 import static com.github.npathai.hamcrestext.matcher.OptionalMatchers.*;
+import static java.lang.String.format;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.endsWith;
 import static org.hamcrest.CoreMatchers.startsWith;
@@ -20,12 +21,8 @@ public class OptionalMatchersTest {
 	
 	@Test
 	public void testIsPresent_ShouldReturnAMatcher_WhichFailsIfOptionalIsEmpty() {
-		exception.expect(AssertionError.class);
-		exception.expectMessage("Expected: <Present>");
-		exception.expectMessage("was <Empty>");
-		
 		Optional<Object> myOptionalRef = Optional.empty();
-		
+		expectFailure(format("Expected: <Present>%n     but: was <Empty>"));
 		assertThat(myOptionalRef, isPresent());
 	}
 	
@@ -45,21 +42,15 @@ public class OptionalMatchersTest {
 	
 	@Test
 	public void testIsEmpty_ShouldReturnAMatcher_WhichFailsIfOptionalIsPresent() {
-		exception.expect(AssertionError.class);
-		exception.expectMessage("Expected: <Empty>");
-		exception.expectMessage("was <Present> with value " + ANY_VALUE);
-		
 		Optional<Object> myOptionalRef = Optional.of(ANY_VALUE);
-		
+		expectFailure(format("Expected: <Empty>%n     but: was <Present> with value " + ANY_VALUE));
 		assertThat("An optional with some value should not be empty", myOptionalRef, isEmpty());
 	}
 
 	@Test
 	public void testHasValue_Object_ShouldReturnAMatcher_WhichFailsIfOptionalIsEmpty() {
-		exception.expect(AssertionError.class);
-		exception.expectMessage("was <Empty>");
-
 		Optional<String> optional = Optional.empty();
+		expectFailure("was <Empty>");
 		assertThat(optional, hasValue("dummy value"));
 	}
 
@@ -71,20 +62,15 @@ public class OptionalMatchersTest {
 
 	@Test
 	public void testHasValue_Object_ShouldReturnAMatcher_WhichFailsIfOptionalContainsValueNotEqualToOperand() {
-		exception.expect(AssertionError.class);
-		exception.expectMessage("was <Present> and");
-		exception.expectMessage("was \"dummy value\"");
-
 		Optional<String> optional = Optional.of("dummy value");
+		expectFailure("was <Present> and was \"dummy value\"");
 		assertThat(optional, hasValue("another value"));
 	}
 	
 	@Test
 	public void testHasValue_Matcher_ShouldReturnAMatcher_WhichFailsIfOptionalIsEmpty() {
-		exception.expect(AssertionError.class);
-		exception.expectMessage("was <Empty>");
-		
 		Optional<String> hello = Optional.empty();
+		expectFailure("was <Empty>");
 		assertThat(hello, hasValue(startsWith("a")));
 	}
 	
@@ -96,11 +82,13 @@ public class OptionalMatchersTest {
 	
 	@Test
 	public void testHasValue_Matcher_ShouldReturnAMatcher_WhichFailsIfOptionalIsPresent_ButPassedMatcher_Fails() {
-		exception.expect(AssertionError.class);
-		exception.expectMessage("was <Present> and");
-		exception.expectMessage("was \"hello\"");
-		
 		Optional<String> hello = Optional.of("hello");
+		expectFailure("was <Present> and was \"hello\"");
 		assertThat(hello, hasValue(startsWith("a")));
+	}
+
+	private void expectFailure(String message) {
+		exception.expect(AssertionError.class);
+		exception.expectMessage(message);
 	}
 }

--- a/src/test/java/com/github/npathai/hamcrestext/matcher/OptionalMatchersTest.java
+++ b/src/test/java/com/github/npathai/hamcrestext/matcher/OptionalMatchersTest.java
@@ -19,7 +19,7 @@ public class OptionalMatchersTest {
 	public void testIsPresent_ShouldReturnAMatcher_WhichFailsIfOptionalIsEmpty() {
 		Optional<Object> myOptionalRef = Optional.empty();
 		expectFailure(
-				"Expected: <Present>",
+				"Expected: is <Present>",
 				"     but: was <Empty>");
 		assertThat(myOptionalRef, isPresent());
 	}
@@ -42,8 +42,8 @@ public class OptionalMatchersTest {
 	public void testIsEmpty_ShouldReturnAMatcher_WhichFailsIfOptionalIsPresent() {
 		Optional<Object> myOptionalRef = Optional.of("dummy value");
 		expectFailure(
-				"Expected: <Empty>",
-				"     but: was <Present> with value dummy value");
+				"Expected: is <Empty>",
+				"     but: had value \"dummy value\"");
 		assertThat(myOptionalRef, isEmpty());
 	}
 
@@ -51,7 +51,7 @@ public class OptionalMatchersTest {
 	public void testHasValue_Object_ShouldReturnAMatcher_WhichFailsIfOptionalIsEmpty() {
 		Optional<String> optional = Optional.empty();
 		expectFailure(
-				"Expected: <Present> and \"dummy value\"",
+				"Expected: has value that is \"dummy value\"",
 				"     but: was <Empty>");
 		assertThat(optional, hasValue("dummy value"));
 	}
@@ -66,8 +66,8 @@ public class OptionalMatchersTest {
 	public void testHasValue_Object_ShouldReturnAMatcher_WhichFailsIfOptionalContainsValueNotEqualToOperand() {
 		Optional<String> optional = Optional.of("dummy value");
 		expectFailure(
-				"Expected: <Present> and \"another value\"",
-				"     but: was <Present> and was \"dummy value\"");
+				"Expected: has value that is \"another value\"",
+				"     but: value was \"dummy value\"");
 		assertThat(optional, hasValue("another value"));
 	}
 	
@@ -75,7 +75,7 @@ public class OptionalMatchersTest {
 	public void testHasValue_Matcher_ShouldReturnAMatcher_WhichFailsIfOptionalIsEmpty() {
 		Optional<String> hello = Optional.empty();
 		expectFailure(
-				"Expected: <Present> and a string starting with \"a\"",
+				"Expected: has value that is a string starting with \"a\"",
 				"     but: was <Empty>");
 		assertThat(hello, hasValue(startsWith("a")));
 	}
@@ -90,8 +90,8 @@ public class OptionalMatchersTest {
 	public void testHasValue_Matcher_ShouldReturnAMatcher_WhichFailsIfOptionalIsPresent_ButPassedMatcher_Fails() {
 		Optional<String> hello = Optional.of("hello");
 		expectFailure(
-				"Expected: <Present> and a string starting with \"a\"",
-				"     but: was <Present> and was \"hello\"");
+				"Expected: has value that is a string starting with \"a\"",
+				"     but: value was \"hello\"");
 		assertThat(hello, hasValue(startsWith("a")));
 	}
 

--- a/src/test/java/com/github/npathai/hamcrestext/matcher/OptionalMatchersTest.java
+++ b/src/test/java/com/github/npathai/hamcrestext/matcher/OptionalMatchersTest.java
@@ -2,10 +2,8 @@ package com.github.npathai.hamcrestext.matcher;
 
 import static com.github.npathai.hamcrestext.matcher.OptionalMatchers.*;
 import static java.lang.String.format;
-import static org.hamcrest.CoreMatchers.allOf;
-import static org.hamcrest.CoreMatchers.endsWith;
-import static org.hamcrest.CoreMatchers.startsWith;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.Optional;
 
@@ -15,20 +13,20 @@ import org.junit.rules.ExpectedException;
 
 public class OptionalMatchersTest {
 
-	private static final Object ANY_VALUE = "value";
-
 	@Rule public ExpectedException exception = ExpectedException.none();
 	
 	@Test
 	public void testIsPresent_ShouldReturnAMatcher_WhichFailsIfOptionalIsEmpty() {
 		Optional<Object> myOptionalRef = Optional.empty();
-		expectFailure(format("Expected: <Present>%n     but: was <Empty>"));
+		expectFailure(
+				"Expected: <Present>",
+				"     but: was <Empty>");
 		assertThat(myOptionalRef, isPresent());
 	}
 	
 	@Test
 	public void testIsPresent_ShouldReturnAMatcher_WhichSucceedsIfOptionalIsPresent() {
-		Optional<Object> myOptionalRef = Optional.of(ANY_VALUE);
+		Optional<Object> myOptionalRef = Optional.of("dummy value");
 		
 		assertThat(myOptionalRef, isPresent());
 	}
@@ -42,15 +40,19 @@ public class OptionalMatchersTest {
 	
 	@Test
 	public void testIsEmpty_ShouldReturnAMatcher_WhichFailsIfOptionalIsPresent() {
-		Optional<Object> myOptionalRef = Optional.of(ANY_VALUE);
-		expectFailure(format("Expected: <Empty>%n     but: was <Present> with value " + ANY_VALUE));
-		assertThat("An optional with some value should not be empty", myOptionalRef, isEmpty());
+		Optional<Object> myOptionalRef = Optional.of("dummy value");
+		expectFailure(
+				"Expected: <Empty>",
+				"     but: was <Present> with value dummy value");
+		assertThat(myOptionalRef, isEmpty());
 	}
 
 	@Test
 	public void testHasValue_Object_ShouldReturnAMatcher_WhichFailsIfOptionalIsEmpty() {
 		Optional<String> optional = Optional.empty();
-		expectFailure("was <Empty>");
+		expectFailure(
+				"Expected: <Present> and \"dummy value\"",
+				"     but: was <Empty>");
 		assertThat(optional, hasValue("dummy value"));
 	}
 
@@ -63,14 +65,18 @@ public class OptionalMatchersTest {
 	@Test
 	public void testHasValue_Object_ShouldReturnAMatcher_WhichFailsIfOptionalContainsValueNotEqualToOperand() {
 		Optional<String> optional = Optional.of("dummy value");
-		expectFailure("was <Present> and was \"dummy value\"");
+		expectFailure(
+				"Expected: <Present> and \"another value\"",
+				"     but: was <Present> and was \"dummy value\"");
 		assertThat(optional, hasValue("another value"));
 	}
 	
 	@Test
 	public void testHasValue_Matcher_ShouldReturnAMatcher_WhichFailsIfOptionalIsEmpty() {
 		Optional<String> hello = Optional.empty();
-		expectFailure("was <Empty>");
+		expectFailure(
+				"Expected: <Present> and a string starting with \"a\"",
+				"     but: was <Empty>");
 		assertThat(hello, hasValue(startsWith("a")));
 	}
 	
@@ -83,12 +89,15 @@ public class OptionalMatchersTest {
 	@Test
 	public void testHasValue_Matcher_ShouldReturnAMatcher_WhichFailsIfOptionalIsPresent_ButPassedMatcher_Fails() {
 		Optional<String> hello = Optional.of("hello");
-		expectFailure("was <Present> and was \"hello\"");
+		expectFailure(
+				"Expected: <Present> and a string starting with \"a\"",
+				"     but: was <Present> and was \"hello\"");
 		assertThat(hello, hasValue(startsWith("a")));
 	}
 
-	private void expectFailure(String message) {
+	private void expectFailure(String firstLineOfMessage, String secondLineOfMessage) {
+		String expectedMessage = format("%n" + firstLineOfMessage + "%n" + secondLineOfMessage);
 		exception.expect(AssertionError.class);
-		exception.expectMessage(message);
+		exception.expectMessage(equalTo(expectedMessage));
 	}
 }


### PR DESCRIPTION
Old `isPresent()` message:

```
Expected: <Present>
     but: was <Empty>
```

New `isPresent()` message:

```
Expected: is <Present>
     but: was <Empty>
```

Old `isEmpty()` message:

```
Expected: <Empty>
     but: was <Present> with value dummy value
```

New `isEmpty()` message:

```
Expected: is <Empty>
     but: had value "dummy value"
```

Old `hasValue()` message:

```
Expected: <Present> and a string starting with "a"
     but: was <Present> and was "hello"
```

New `hasValue()` message:

```
Expected: has value that is a string starting with "a"
     but: value was "hello"
```
