### PR TITLE
Update plugins to current versions:

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.7.2.201409121644</version>
+				<version>0.7.5.201505241946</version>
 				<executions>
 					<execution>
 						<id>prepare-unit-test-agent</id>
@@ -56,7 +56,7 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.12.4</version>
+				<version>2.19</version>
 				<executions>
 					<execution>
 						<id>default-test</id>
@@ -70,7 +70,7 @@
 			<plugin>
 				<groupId>org.eluder.coveralls</groupId>
 				<artifactId>coveralls-maven-plugin</artifactId>
-				<version>3.1.0</version>
+				<version>4.0.0</version>
 			</plugin>
 		</plugins>
 	</build>


### PR DESCRIPTION
maven-surefire-plugin .......................................... 2.19
org.eluder.coveralls:coveralls-maven-plugin ................... 4.0.0
org.jacoco:jacoco-maven-plugin ................... 0.7.5.201505241946
