### PR TITLE
Prepare release.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /target/
 .classpath
+.flattened-pom.xml
 .project
 .settings

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: java
+install: mvn install -DskipTests -Dgpg.skip
 jdk:
   - oraclejdk8
 after_success:

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ hamcrest-optional is build with [Maven](http://maven.apache.org/). If you want
 to contribute code then
 
 * Please write a test for your change.
-* Ensure that you don't break the build by running `mvn test`.
+* Ensure that you don't break the build by running `mvn verify -Dgpg.skip`.
 * Fork the repo and create a pull request. (See [Understanding the GitHub Flow](https://guides.github.com/introduction/flow/index.html))
 
 hamcrest-optional supports [Travis CI](https://travis-ci.org/) for continuous

--- a/README.md
+++ b/README.md
@@ -66,3 +66,14 @@ to contribute code then
 
 hamcrest-optional supports [Travis CI](https://travis-ci.org/) for continuous
 integration. Your pull request is automatically build by Travis CI.
+
+## Release Guide
+
+* Select a new version according to the
+  [Semantic Versioning 2.0.0 Standard](http://semver.org/).
+* Set the new version in `pom.xml`.
+* Commit the modified `pom.xml`.
+* Push the commit: `git push origin master`
+* Run `mvn clean deploy` with JDK 8.
+* Add a tag for the release: `git tag hamcrest-optional-X.X.X`
+* Push the tag: `git push origin hamcrest-optional-X.X.X`

--- a/pom.xml
+++ b/pom.xml
@@ -3,6 +3,12 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
+	<parent>
+		<groupId>com.github.stefanbirkner</groupId>
+		<artifactId>lib-parent</artifactId>
+		<version>8</version>
+	</parent>
+
 	<groupId>com.github.npathai</groupId>
 	<artifactId>hamcrest-optional</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
@@ -56,7 +62,6 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.19</version>
 				<executions>
 					<execution>
 						<id>default-test</id>


### PR DESCRIPTION
Describe the release process and use Stefan Birkner's parent POM. This POM sets versions for all plugins and configures plugins that are used for releasing the library.

I used my own parent POM in order to avoid copying all the plugin configuration. I can create a different pull request with an explicit configuration of the plugins if you don't like to use the parent POM.
