### PR TITLE
rename hasValue to isPresentAnd/isPresentAndIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ An extension to [Java Hamcrest](https://github.com/hamcrest/JavaHamcrest) which 
 ## Usage
 
 hamcrest-optional provides four matchers for `Optional`: `isEmpty()`,
-`isPresent()`, `hasValue(Object)` and `hasValue(Matcher)`.
+`isPresent()`, `isPresentAndIs(Object)` and `isPresentAnd(Matcher)`.
 
 ### isEmpty()
 
@@ -45,29 +45,29 @@ Optional<String> optional = Optional.of("dummy value");
 assertThat(optional, isPresent());
 ```
 
-### hasValue(Object)
+### isPresentAndIs(Object)
 
 This matcher matches when the examined `Optional` contains a value that is
 logically equal to the specified object.
 
 ```java
-import static com.github.npathai.hamcrestopt.OptionalMatchers.hasValue;
+import static com.github.npathai.hamcrestopt.OptionalMatchers.isPresentAndIs;
 
 Optional<String> optional = Optional.of("dummy value");
-assertThat(optional, hasValue("dummy value"));
+assertThat(optional, isPresentAndIs("dummy value"));
 ```
 
-### hasValue(Matcher)
+### isPresentAnd(Matcher)
 
 This matcher matches when the examined `Optional` contains a value that
 satisfies the specified matcher.
 
 ```java
-import static com.github.npathai.hamcrestopt.OptionalMatchers.hasValue;
+import static com.github.npathai.hamcrestopt.OptionalMatchers.isPresentAnd;
 import static org.hamcrest.Matchers.startsWith;
 
 Optional<String> optional = Optional.of("dummy value");
-assertThat(optional, hasValue(startsWith("dummy")));
+assertThat(optional, isPresentAnd(startsWith("dummy")));
 ```
 
 ## Development Guide

--- a/src/main/java/com/github/npathai/hamcrestopt/OptionalMatchers.java
+++ b/src/main/java/com/github/npathai/hamcrestopt/OptionalMatchers.java
@@ -15,15 +15,15 @@ import static org.hamcrest.core.IsEqual.equalTo;
  *     contains no value.</li>
  *     <li>{@link #isPresent()} - matches when the examined {@code Optional}
  *     contains a value.</li>
- *     <li>{@link #hasValue(Object)} - matches when the examined
+ *     <li>{@link #isPresentAndIs(Object)} - matches when the examined
  *     {@code Optional} contains a value that is logically equal to the
  *     {@code operand}.</li>
- *     <li>{@link #hasValue(Matcher)} - matches when the examined
+ *     <li>{@link #isPresentAnd(Matcher)} - matches when the examined
  *     {@code Optional} contains a value that satisfies the specified matcher.
  *     </li>
  * </ul>
  *
- * @author npathai
+ * @author npathai, sweiler
  */
 public class OptionalMatchers {
 
@@ -98,7 +98,7 @@ public class OptionalMatchers {
 	 * determined by calling the {@code equals} method on the value.
 	 * <pre>
 	 *     Optional&lt;String&gt; optionalInt = Optional.of("dummy value");
-	 *     assertThat(optionalInt, hasValue("dummy value"));
+	 *     assertThat(optionalInt, isPresentAndIs("dummy value"));
 	 * </pre>
 	 *
 	 * @param operand the object that any examined {@code Optional} value
@@ -107,7 +107,7 @@ public class OptionalMatchers {
 	 * @return  a matcher that matches when the examined {@code Optional}
 	 * contains a value that is logically equal to the {@code operand}.
 	 */
-	public static <T> Matcher<Optional<T>> hasValue(T operand) {
+	public static <T> Matcher<Optional<T>> isPresentAndIs(T operand) {
 		return new HasValue<>(equalTo(operand));
 	}
 
@@ -116,7 +116,7 @@ public class OptionalMatchers {
 	 * contains a value that satisfies the specified matcher.
 	 * <pre>
 	 *     Optional&lt;String&gt; optionalObject = Optional.of("dummy value");
-	 *     assertThat(optionalObject, hasValue(startsWith("dummy")));
+	 *     assertThat(optionalObject, isPresentAnd(startsWith("dummy")));
 	 * </pre>
 	 *
 	 * @param matcher a matcher for the value of the examined {@code Optional}.
@@ -124,7 +124,7 @@ public class OptionalMatchers {
 	 * @return  a matcher that matches when the examined {@code Optional}
 	 * contains a value that satisfies the specified matcher.
 	 */
-	public static <T> Matcher<Optional<T>> hasValue(Matcher<? super T> matcher) {
+	public static <T> Matcher<Optional<T>> isPresentAnd(Matcher<? super T> matcher) {
 		return new HasValue<>(matcher);
 	}
 

--- a/src/test/java/com/github/npathai/hamcrestopt/OptionalMatchersTest.java
+++ b/src/test/java/com/github/npathai/hamcrestopt/OptionalMatchersTest.java
@@ -53,13 +53,13 @@ public class OptionalMatchersTest {
 		expectFailure(
 				"Expected: has value that is \"dummy value\"",
 				"     but: was <Empty>");
-		assertThat(optional, hasValue("dummy value"));
+		assertThat(optional, isPresentAndIs("dummy value"));
 	}
 
 	@Test
 	public void testHasValue_Object_ShouldReturnAMatcher_WhichSucceedsIfOptionalContainsValueEqualToOperand() {
 		Optional<String> optional = Optional.of("dummy value");
-		assertThat(optional, hasValue("dummy value"));
+		assertThat(optional, isPresentAndIs("dummy value"));
 	}
 
 	@Test
@@ -68,7 +68,7 @@ public class OptionalMatchersTest {
 		expectFailure(
 				"Expected: has value that is \"another value\"",
 				"     but: value was \"dummy value\"");
-		assertThat(optional, hasValue("another value"));
+		assertThat(optional, isPresentAndIs("another value"));
 	}
 	
 	@Test
@@ -77,13 +77,13 @@ public class OptionalMatchersTest {
 		expectFailure(
 				"Expected: has value that is a string starting with \"a\"",
 				"     but: was <Empty>");
-		assertThat(hello, hasValue(startsWith("a")));
+		assertThat(hello, isPresentAnd(startsWith("a")));
 	}
 	
 	@Test
 	public void testHasValue_Matcher_ShouldReturnAMatcher_WhichSucceedsIfOptionalIsPresent_AndPassedMatcher_Succeeds() {
 		Optional<String> hello = Optional.of("hello");
-		assertThat(hello, hasValue(allOf(startsWith("h"), endsWith("o"))));
+		assertThat(hello, isPresentAnd(allOf(startsWith("h"), endsWith("o"))));
 	}
 	
 	@Test
@@ -92,7 +92,7 @@ public class OptionalMatchersTest {
 		expectFailure(
 				"Expected: has value that is a string starting with \"a\"",
 				"     but: value was \"hello\"");
-		assertThat(hello, hasValue(startsWith("a")));
+		assertThat(hello, isPresentAnd(startsWith("a")));
 	}
 
 	private void expectFailure(String firstLineOfMessage, String secondLineOfMessage) {


### PR DESCRIPTION
Avoid naming conflicts with Hamcrest's hasValue
Resolves issue #24, but chose different names to allow for fluent method chains like:
```java
Optional<String> optionalName = Optional.of("some name");
assertThat(optionalName, isPresentAnd(startsWith("some")));
```